### PR TITLE
Fix being able to pipe in Data Models that are blacklisted or aren't the right tier in the Simulator Modeling

### DIFF
--- a/src/main/java/net/lmor/extrahnn/tile/SimulationModelingTileEntity.java
+++ b/src/main/java/net/lmor/extrahnn/tile/SimulationModelingTileEntity.java
@@ -7,6 +7,7 @@ import dev.shadowsoffire.placebo.block_entity.TickingBlockEntity;
 import dev.shadowsoffire.placebo.cap.InternalItemHandler;
 import dev.shadowsoffire.placebo.cap.ModifiableEnergyStorage;
 import dev.shadowsoffire.placebo.menu.SimpleDataSlots;
+import net.lmor.extrahnn.EHNNUtils;
 import net.lmor.extrahnn.ExtraHostile;
 import net.lmor.extrahnn.ExtraHostileConfig;
 import net.lmor.extrahnn.data.ExtraCachedModel;
@@ -123,6 +124,12 @@ public class SimulationModelingTileEntity extends BlockEntity implements Ticking
             startCraft = false;
             return;
         }
+
+        if (!EHNNUtils.allowedBlackListModel(item) || !EHNNUtils.allowedTier(item)){
+            startCraft = false;
+            return;
+        }
+
 
         if (this.runtime == 0){
             this.runtime = runtimeUpgrade;


### PR DESCRIPTION
Using any item pipe, you are able to pipe in Data Models even though they are blacklisted of not the right tier as set in the config files.

This PR adds a check to ensure Data Models aren't leveld up if they are blacklisted of not the right tier.